### PR TITLE
Add support for megabundle querying and new attribute "isMegabundle" in response

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -360,7 +360,7 @@ app.get('/v1/blocks', async (req, res) => {
       const isMegabundle = isMegabundleBlock(mergedByBlockNumber[blockNumber], megabundleByBlockNumber[blockNumber])
       return {
         ...(isMegabundle ? megabundleByBlockNumber[blockNumber] : mergedByBlockNumber[blockNumber]),
-        isMegabundle: isMegabundle
+        isMegabundle
       }
     })
     const latestBlockNumber = await sql`select max(block_number) as block_number from blocks`


### PR DESCRIPTION
Currently, selects based on whichever has more transactions, but could easily add logic to `isMegabundleBlock`. Output below shows new key `isMegabundle` 

```
{
  "blocks": [
    {
      "block_number": 13621230,
      "miner_reward": "1770419031770855",
      "miner": "0x45a36a8e118C37e4c47eF4Ab827A7C9e579E11E2",
      "coinbase_transfers": "1770419031770855",
      "gas_used": 257921,
      "gas_price": "6864191096",
      "transactions": [
        {
          "transaction_hash": "0x0c371dc67c6f8ceb5ef2496e5a9fb6c49be68632b946e02c00b3e40eacd5e9af",
          "tx_index": 0,
          "bundle_type": "flashbots",
          "bundle_index": 0,
          "block_number": 13621230,
          "eoa_address": "0x0000e0C70000ca6bc5006838e7cc3e7C8fD23D00",
          "to_address": "0x91000060399502550000007bbfBA0052F47B008A",
          "gas_used": 257921,
          "gas_price": "6864191096",
          "coinbase_transfer": "1770419031770855",
          "total_miner_reward": "1770419031770855"
        }
      ],
      "isMegabundle": false
    }
  ],
  "latest_block_number": 13621527
}
```