### PR TITLE
Add mega bundle detection at the transaction level, instead of block

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -364,7 +364,7 @@ app.get('/v1/blocks', async (req, res) => {
         const megaBundleTx = megaBundleTransactions[i]
         if (megaBundleTx === undefined) return mergedTransaction
         const bundle_type =
-          megaBundleTx.transaction_hash !== mergedTransaction.transaction_hash ? mergedTransaction.bundle_type : 'megabundle'
+          megaBundleTx.transaction_hash === mergedTransaction.transaction_hash ? 'megabundle' : mergedTransaction.bundle_type
         return {
           ...mergedTransaction,
           bundle_type


### PR DESCRIPTION
We want to be able to identify "mega bundles" when they appear in blocks. While miners are running both "merged bundles" and "mega bundles", we need to support both concurrently and find an effective way to switch between the two. The problem is that merged-bundles are a superset of mega-bundles (since mega-bundles are just an array of the same bundles being considered in merged-bundles), so a mega-bundle could never be "longer" or "more profitable" at inspection time (although it easily could be at miner time!). The two extremes here are:

1 block matches a mega bundle and merged bundle at same time. mega-bundle is 1 bundle, merged bundle is 5 bundles.
1 block matches a mega bundle and merged bundle at same time. mega-bundle is 30 bundles, merged bundle is 30 bundles

It seems pretty likely the first one is not a mega-bundle and the second one is. But even the first one might be (from dual submission)? So the plan is make the "mega-bundle" identification per BUNDLE, not per block. so the first block would look like this:

Bundle #1 - Flashbots Megabundle
Bundle #2 - Flashbots
Bundle #3 - Flashbots